### PR TITLE
Make OAuth2 implementation less shoddy.

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -13,7 +13,9 @@ type Event int
 const (
 	EventRegister Event = iota
 	EventAuth
+	EventOAuth
 	EventAuthFail
+	EventOAuthFail
 	EventRecoverStart
 	EventRecoverEnd
 	EventGet
@@ -21,14 +23,15 @@ const (
 	EventPasswordReset
 )
 
-const eventNames = "EventRegisterEventAuthEventAuthFailEventRecoverStartEventRecoverEndEventGetEventGetUserSessionEventPasswordReset"
+const eventNames = "EventRegisterEventAuthEventOAuthEventAuthFailEventOAuthFailEventRecoverStartEventRecoverEndEventGetEventGetUserSessionEventPasswordReset"
 
-var eventIndexes = [...]uint8{0, 13, 22, 35, 52, 67, 75, 94, 112}
+var eventIndexes = [...]uint8{0, 13, 22, 32, 45, 59, 76, 91, 99, 118, 136}
 
 func (i Event) String() string {
 	if i < 0 || i+1 >= Event(len(eventIndexes)) {
 		return fmt.Sprintf("Event(%d)", i)
 	}
+
 	return eventNames[eventIndexes[i]:eventIndexes[i+1]]
 }
 

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -160,7 +160,9 @@ func TestEventString(t *testing.T) {
 	}{
 		{EventRegister, "EventRegister"},
 		{EventAuth, "EventAuth"},
+		{EventOAuth, "EventOAuth"},
 		{EventAuthFail, "EventAuthFail"},
+		{EventOAuthFail, "EventOAuthFail"},
 		{EventRecoverStart, "EventRecoverStart"},
 		{EventRecoverEnd, "EventRecoverEnd"},
 		{EventGet, "EventGet"},

--- a/config.go
+++ b/config.go
@@ -68,6 +68,7 @@ type Config struct {
 	XSRFMaker XSRF
 
 	Storer            Storer
+	OAuth2Storer      OAuth2Storer
 	CookieStoreMaker  CookieStoreMaker
 	SessionStoreMaker SessionStoreMaker
 	LogWriter         io.Writer

--- a/context.go
+++ b/context.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+var (
+	FormValueRedirect    = "redir"
+	FormValueOAuth2State = "state"
+)
+
 // Context provides context for module operations and callbacks. One obvious
 // need for context is a request's session store. It is not safe for use by
 // multiple goroutines.
@@ -100,12 +105,19 @@ func (c *Context) LoadUser(key string) error {
 		return nil
 	}
 
-	intf, err := Cfg.Storer.Get(key, ModuleAttrMeta)
+	var user interface{}
+	var err error
+
+	if index := strings.IndexByte(key, ';'); index > 0 {
+		user, err = Cfg.OAuth2Storer.GetOAuth(key[:index], key[index+1:], ModuleAttrMeta)
+	} else {
+		user, err = Cfg.Storer.Get(key, ModuleAttrMeta)
+	}
 	if err != nil {
 		return err
 	}
 
-	c.User = Unbind(intf)
+	c.User = Unbind(user)
 	return nil
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -95,22 +95,51 @@ func TestContext_SaveUser(t *testing.T) {
 func TestContext_LoadUser(t *testing.T) {
 	Cfg = NewConfig()
 	ctx := NewContext()
+
+	attr := Attributes{
+		"email":    "hello@joe.com",
+		"password": "mysticalhash",
+		"uid":      "what",
+		"provider": "google",
+	}
+
 	storer := mockStorer{
-		"joe": Attributes{"email": "hello@joe.com", "password": "mysticalhash"},
+		"joe":        attr,
+		"whatgoogle": attr,
 	}
 	Cfg.Storer = storer
+	Cfg.OAuth2Storer = storer
 
-	err := ctx.LoadUser("joe")
-	if err != nil {
+	ctx.User = nil
+	if err := ctx.LoadUser("joe"); err != nil {
 		t.Error("Unexpected error:", err)
 	}
 
-	attr := storer["joe"]
+	if email, err := ctx.User.StringErr("email"); err != nil {
+		t.Error(err)
+	} else if email != attr["email"] {
+		t.Error("Email wrong:", email)
+	}
+	if password, err := ctx.User.StringErr("password"); err != nil {
+		t.Error(err)
+	} else if password != attr["password"] {
+		t.Error("Password wrong:", password)
+	}
 
-	for k, v := range attr {
-		if v != ctx.User[k] {
-			t.Error(v, "not equal to", ctx.User[k])
-		}
+	ctx.User = nil
+	if err := ctx.LoadUser("what;google"); err != nil {
+		t.Error("Unexpected error:", err)
+	}
+
+	if email, err := ctx.User.StringErr("email"); err != nil {
+		t.Error(err)
+	} else if email != attr["email"] {
+		t.Error("Email wrong:", email)
+	}
+	if password, err := ctx.User.StringErr("password"); err != nil {
+		t.Error(err)
+	} else if password != attr["password"] {
+		t.Error("Password wrong:", password)
 	}
 }
 

--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -91,6 +91,39 @@ func (m *MockStorer) Get(key string, attrMeta authboss.AttributeMeta) (result in
 	return u, nil
 }
 
+func (m *MockStorer) PutOAuth(uid, provider string, attr authboss.Attributes) error {
+	if len(m.PutErr) > 0 {
+		return errors.New(m.PutErr)
+	}
+
+	if _, ok := m.Users[uid+provider]; !ok {
+		m.Users[uid+provider] = attr
+		return nil
+	}
+	for k, v := range attr {
+		m.Users[uid+provider][k] = v
+	}
+	return nil
+}
+
+func (m *MockStorer) GetOAuth(uid, provider string, attrMeta authboss.AttributeMeta) (result interface{}, err error) {
+	if len(m.GetErr) > 0 {
+		return nil, errors.New(m.GetErr)
+	}
+
+	userAttrs, ok := m.Users[uid+provider]
+	if !ok {
+		return nil, authboss.ErrUserNotFound
+	}
+
+	u := &MockUser{}
+	if err := userAttrs.Bind(u, true); err != nil {
+		panic(err)
+	}
+
+	return u, nil
+}
+
 func (m *MockStorer) AddToken(key, token string) error {
 	if len(m.AddTokenErr) > 0 {
 		return errors.New(m.AddTokenErr)

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -29,6 +29,17 @@ func (m mockStorer) Get(key string, attrMeta AttributeMeta) (result interface{},
 	}, nil
 }
 
+func (m mockStorer) PutOAuth(uid, provider string, attr Attributes) error {
+	m[uid+provider] = attr
+	return nil
+}
+
+func (m mockStorer) GetOAuth(uid, provider string, attrMeta AttributeMeta) (result interface{}, err error) {
+	return &mockUser{
+		m[uid+provider]["email"].(string), m[uid+provider]["password"].(string),
+	}, nil
+}
+
 type mockClientStore map[string]string
 
 func (m mockClientStore) Get(key string) (string, bool) {

--- a/oauth2.go
+++ b/oauth2.go
@@ -6,20 +6,28 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// OAuth2Provider is the entire configuration
-// required to authenticate with this provider.
-//
-// The OAuth2Config does not need a redirect URL because it will
-// be automatically created by the
+/*
+OAuth2Provider is the entire configuration
+required to authenticate with this provider.
+
+The OAuth2Config does not need a redirect URL because it will
+be automatically created by the route registration in oauth2 module.
+
+AdditionalParams can be used to specify extra parameters to tack on to the
+end of the initial request, this allows for provider specific oauth options
+like access_type=offline to be passed to the provider.
+
+Callback gives the config and the token allowing an http client using the
+authenticated token to be created. Because each OAuth2 implementation has a different
+API this must be handled for each provider separately. It is used to return two things
+specifically: UID (the ID according to the provider) and the Email address.
+The UID must be passed back or there will be an error as it is the means of identifying the
+user in the system, e-mail is optional but should be returned in systems using
+emailing. The keys authboss.StoreOAuth2UID and authboss.StoreEmail can be used to set
+these values in the authboss.Attributes map returned by the callback.
+*/
 type OAuthProvider struct {
 	OAuth2Config     *oauth2.Config
 	AdditionalParams url.Values
-	Callback         func(oauth2.Config, *oauth2.Token) (OAuth2Credentials, error)
-}
-
-// OAuth2Credentials are used to store in the database.
-// Email is optional
-type OAuth2Credentials struct {
-	UID   string
-	Email string
+	Callback         func(oauth2.Config, *oauth2.Token) (Attributes, error)
 }

--- a/oauth2/providers.go
+++ b/oauth2/providers.go
@@ -26,21 +26,22 @@ type googleMeResponse struct {
 var clientGet = (*http.Client).Get
 
 // Google is a callback appropriate for use with Google's OAuth2 configuration.
-func Google(cfg oauth2.Config, token *oauth2.Token) (cred authboss.OAuth2Credentials, err error) {
+func Google(cfg oauth2.Config, token *oauth2.Token) (authboss.Attributes, error) {
 	client := cfg.Client(oauth2.NoContext, token)
 	resp, err := clientGet(client, googleInfoEndpoint)
 	if err != nil {
-		return cred, err
+		return nil, err
 	}
 
 	defer resp.Body.Close()
 	dec := json.NewDecoder(resp.Body)
 	var jsonResp googleMeResponse
 	if err = dec.Decode(&jsonResp); err != nil {
-		return cred, err
+		return nil, err
 	}
 
-	cred.UID = jsonResp.ID
-	cred.Email = jsonResp.Email
-	return cred, nil
+	return authboss.Attributes{
+		authboss.StoreOAuth2UID: jsonResp.ID,
+		authboss.StoreEmail:     jsonResp.Email,
+	}, nil
 }

--- a/oauth2/providers_test.go
+++ b/oauth2/providers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+	"gopkg.in/authboss.v0"
 )
 
 func TestGoogle(t *testing.T) {
@@ -30,15 +31,15 @@ func TestGoogle(t *testing.T) {
 		Expiry:       time.Now().Add(60 * time.Minute),
 	}
 
-	cred, err := Google(cfg, tok)
+	user, err := Google(cfg, tok)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if cred.UID != "id" {
-		t.Error("UID wrong:", cred.UID)
+	if uid, ok := user[authboss.StoreOAuth2UID]; !ok || uid != "id" {
+		t.Error("UID wrong:", uid)
 	}
-	if cred.Email != "email" {
-		t.Error("Email wrong:", cred.Email)
+	if email, ok := user[authboss.StoreEmail]; !ok || email != "email" {
+		t.Error("Email wrong:", email)
 	}
 }

--- a/recover/recover_test.go
+++ b/recover/recover_test.go
@@ -251,7 +251,7 @@ func TestRecover_sendRecoverEmail(t *testing.T) {
 
 	mailer := mocks.NewMockMailer()
 	authboss.Cfg.EmailSubjectPrefix = "foo "
-	authboss.Cfg.HostName = "bar"
+	authboss.Cfg.RootURL = "bar"
 	authboss.Cfg.Mailer = mailer
 
 	a.sendRecoverEmail("a@b.c", "abc=")
@@ -265,7 +265,7 @@ func TestRecover_sendRecoverEmail(t *testing.T) {
 		t.Error("Unexpected subject:", mailer.Last.Subject)
 	}
 
-	url := fmt.Sprintf("%s/recover/complete?token=abc=", authboss.Cfg.HostName)
+	url := fmt.Sprintf("%s/recover/complete?token=abc=", authboss.Cfg.RootURL)
 	if !strings.Contains(mailer.Last.HTMLBody, url) {
 		t.Error("Expected HTMLBody to contain url:", url)
 	}
@@ -409,11 +409,11 @@ func TestRecover_completeHanlderFunc_POST(t *testing.T) {
 	}
 
 	if !cbCalled {
-		t.Error("Expected EventPasswordReste callback to have been fired")
+		t.Error("Expected EventPasswordReset callback to have been fired")
 	}
 
 	if val, ok := sessionStorer.Get(authboss.SessionKey); !ok || val != "john" {
-		t.Errorf("Ecxpected SessionKey to be:", "john")
+		t.Error("Expected SessionKey to be:", "john")
 	}
 
 	if w.Code != http.StatusFound {

--- a/storer.go
+++ b/storer.go
@@ -20,9 +20,11 @@ const (
 
 // Data store constants for OAuth2 attribute names.
 const (
-	StoreOAuth2Token   = "oauth2_token"
-	StoreOAuth2Refresh = "oauth2_refresh"
-	StoreOAuth2Expiry  = "oauth2_expiry"
+	StoreOAuth2UID      = "oauth2_uid"
+	StoreOAuth2Provider = "oauth2_provider"
+	StoreOAuth2Token    = "oauth2_token"
+	StoreOAuth2Refresh  = "oauth2_refresh"
+	StoreOAuth2Expiry   = "oauth2_expiry"
 )
 
 var (
@@ -39,14 +41,23 @@ type StorageOptions map[string]DataType
 // The type of store is up to the developer implementing it, and all it has to
 // do is be able to store several simple types.
 type Storer interface {
-	// Put is for storing the attributes passed in. The type information can
-	// help serialization without using type assertions.
+	// Put is for storing the attributes passed in using the key. This is an
+	// update only method and should not store if it does not find the key.
 	Put(key string, attr Attributes) error
 	// Get is for retrieving attributes for a given key. The return value
 	// must be a struct that contains all fields with the correct types as shown
 	// by attrMeta. If the key is not found in the data store simply
 	// return nil, ErrUserNotFound.
 	Get(key string, attrMeta AttributeMeta) (interface{}, error)
+}
+
+// OAuth2Storer is a replacement (or addition) to the Storer interface.
+// It allows users to be stored and fetched via a uid/provider combination.
+type OAuth2Storer interface {
+	// PutOAuth creates or updates an existing record (unlike Storer.Put)
+	// because in the OAuth flow there is no separate create/update.
+	PutOAuth(uid, provider string, attr Attributes) error
+	GetOAuth(uid, provider string, attrMeta AttributeMeta) (interface{}, error)
 }
 
 // DataType represents the various types that clients must be able to store.


### PR DESCRIPTION
- Add a new storer specifically for OAuth2 to enable clients to choose regular database storing OR Oauth2 but not have to have both.
- Stop storing OAuth2 credentials in a combined form inside username.
- Add new events to capture OAuth events just like auth.
- Have pass-through parameters for OAuth init urls, this allows us to pass additional behavior options (redirects and remember me) as well as other things that should be present on the page that is redirected to.
- Context.LoadUser is now OAuth aware.
- Remember's callbacks now include an OAuth check to see if a horribly packed state variable contains a flag to say that we want to be remembered.
- Change the OAuth2 Callback to use Attributes instead of that custom struct to allow people to append whatever attributes they want into the user that will be saved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced OAuth2 functionality with new events for OAuth success and failure.
  - Added support for storing and retrieving OAuth2 information.

- **Enhancements**
  - Updated user loading mechanism to handle more complex key structures.
  - Improved OAuth2 provider handling and callback functionality.

- **Bug Fixes**
  - Adjusted tests to align with new OAuth2 features and configurations.

- **Documentation**
  - Added comprehensive documentation for new OAuth2-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->